### PR TITLE
Update 'requests' -> 2.12.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,10 @@ tests/__pycache__/
 __pycache__
 logs/
 *.pyc
-.idea/
+.Python
+bin/
+lib/
+include/
+pip-selfcheck.json
 venv/
+.idea/

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ language: python
 python:
     - "3.5"
 install:
-- "pip install -r requirements.txt"
-- "pip install -r test_requirements.txt"
+    - make
 script:
-- flake8
-- python -m unittest tests/*.py
+    - make test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,8 @@
-FROM onsdigital/flask-crypto
+FROM onsdigital/flask-crypto-queue
 
 ADD app /app
-ADD requirements.txt /requirements.txt
 ADD startup.sh /startup.sh
 
 RUN mkdir -p /app/logs
-
-RUN pip3 install --no-cache-dir -U -I -r /requirements.txt
 
 ENTRYPOINT ./startup.sh

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+build:
+	pip install -r requirements.txt
+
+test:
+	flake8 --exclude lib
+	python3 -m unittest tests/*.py

--- a/Makefile
+++ b/Makefile
@@ -2,5 +2,6 @@ build:
 	pip install -r requirements.txt
 
 test:
+	pip install -r test_requirements.txt
 	flake8 --exclude lib
 	python3 -m unittest tests/*.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-requests==2.10.0
+requests==2.12.4
 pika==0.10.0
 Jinja2==2.8
 six==1.10.0


### PR DESCRIPTION
Don't need to have requirements call in docker file as dependencies are present in the onsdigital/flask-crypto-queue base image.