### PR TITLE
Feature/remove queue reject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### Unreleased
   - Add support for encrypted queue messages from ``sdx-collect``
   - Add change log
+  - Remove reject on max retries. Stops message being rejected if endpoint is down for prolonged period
 
 ### 1.0.0 2016-11-22
   - Initial release

--- a/README.md
+++ b/README.md
@@ -2,4 +2,19 @@
 
 [![Build Status](https://travis-ci.org/ONSdigital/sdx-receipt-rrm.svg?branch=develop)](https://travis-ci.org/ONSdigital/sdx-receipt-rrm)
 
-The sdx-receipt-rrm app is a component of the Office of National Statistics (ONS) Survey Data Exchange (SDX) project which sends receipts to RRM endpoint.
+``sdx-receipt-rrm`` is a component of the Office for National Statistics (ONS) Survey Data Exchange (SDX) product which sends receipts to RRM.
+
+## Configuration
+
+The main configuration options are listed below:
+
+| Environment Variable            | Default       | Description
+|---------------------------------|---------------|--------------
+| RECEIPT_HOST                    | _none_        | Host for rrm receipt service
+| RECEIPT_PATH                    | _none_        | Path for rrm receipt service
+| RECEIPT_USER                    | _none_        | User for rrm receipt service
+| RECEIPT_PASS                    | _none_        | Password for rmm receipt service
+| RABBIT_QUEUE                    | `rrm_receipt` | Incoming queue to read from
+| RABBIT_EXCHANGE                 | `message`     | RabbitMQ exchange to use
+| RECEIPT_SECRET                  | _none_        | Key for decrypting messages from queue. Must be the same as used for ``sdx-collect``
+| LOGGING_LEVEL                   | `DEBUG`       | Logging sensitivity

--- a/app/consumer.py
+++ b/app/consumer.py
@@ -8,39 +8,19 @@ logging.basicConfig(level=settings.LOGGING_LEVEL, format=settings.LOGGING_FORMAT
 logger = wrap_logger(logging.getLogger(__name__))
 
 
-def get_delivery_count_from_properties(properties):
-    delivery_count = 0
-    if properties.headers and 'x-delivery-count' in properties.headers:
-        delivery_count = properties.headers['x-delivery-count']
-
-    return delivery_count
-
-
 class Consumer(AsyncConsumer):
     def on_message(self, unused_channel, basic_deliver, properties, body):
         logger.info('Received message', delivery_tag=basic_deliver.delivery_tag, app_id=properties.app_id, body=body.decode("utf-8"))
-
-        delivery_count = get_delivery_count_from_properties(properties)
-        delivery_count += 1
 
         processor = ResponseProcessor(logger)
         options = ResponseProcessor.options()
 
         try:
             message = body.decode("utf-8")
-
             processed_ok = processor.process(message, **options)
 
             if processed_ok:
                 self.acknowledge_message(basic_deliver.delivery_tag, tx_id=processor.tx_id)
-            elif delivery_count == settings.QUEUE_MAX_MESSAGE_DELIVERIES:
-                logger.error(
-                    "Reached maximum number of retries",
-                    tx_id=processor.tx_id,
-                    delivery_count=delivery_count,
-                    message=message
-                )
-                self.reject_message(basic_deliver.delivery_tag, tx_id=processor.tx_id)
 
         except Exception as e:
             logger.error("ResponseProcessor failed", exception=e, tx_id=processor.tx_id)

--- a/app/response_processor.py
+++ b/app/response_processor.py
@@ -16,7 +16,7 @@ class ResponseProcessor:
         rv = {}
         try:
             rv["secret"] = os.getenv("SDX_RECEIPT_RRM_SECRET").encode("ascii")
-        except Exception as e:
+        except Exception:
             # No secret in env
             pass
         return rv

--- a/app/settings.py
+++ b/app/settings.py
@@ -17,7 +17,6 @@ RECEIPT_PASS = os.getenv("RECEIPT_PASS", "")
 
 RABBIT_QUEUE = os.getenv('RABBITMQ_QUEUE', 'rrm_receipt')
 RABBIT_EXCHANGE = os.getenv('RABBITMQ_EXCHANGE', 'message')
-QUEUE_MAX_MESSAGE_DELIVERIES = 3
 
 RABBIT_URL = 'amqp://{user}:{password}@{hostname}:{port}/{vhost}'.format(
     hostname=os.getenv('RABBITMQ_HOST', 'rabbit'),


### PR DESCRIPTION
Allow retrying if endpoint down for a prolonged period.

``QUEUE_MAX_MESSAGE_DELIVERIES`` env var no longer required.