### PR TITLE
Remove Rabbit URL from logging message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Unreleased
   - Add the service being called to `calling service` logging message
+  - Remove the Rabbit URL from logging message
 
 ### 2.1.0 2017-03-15
   - Log version number on startup

--- a/app/async_consumer.py
+++ b/app/async_consumer.py
@@ -51,7 +51,7 @@ class AsyncConsumer(object):
             self._url = settings.RABBIT_URLS[server_choice]
 
             try:
-                logger.info('Connecting', amqp_url=self._url, attempt=count)
+                logger.info('Connecting', attempt=count)
                 return pika.SelectConnection(pika.URLParameters(self._url),
                                              self.on_connection_open,
                                              stop_ioloop_on_close=False)


### PR DESCRIPTION
Remove Rabbit URL from logging messages to prevent Rabbit credentials being logged out.