### PR TITLE
Handle network errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### Unreleased
+  - Handle network errors using the ConnectionError exception class and  requeing the message
 
 ### 2.4.0 2017-09-11
   - Removed SDX common clone in docker

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ### Unreleased
-  - Handle network errors using the ConnectionError exception class and  requeing the message
+  - Handle network errors using the ConnectionError exception class and requeing the message
 
 ### 2.4.0 2017-09-11
   - Removed SDX common clone in docker

--- a/app/main.py
+++ b/app/main.py
@@ -41,5 +41,6 @@ def run():
     except KeyboardInterrupt:
         message_consumer.stop()
 
+
 if __name__ == '__main__':
     run()

--- a/app/response_processor.py
+++ b/app/response_processor.py
@@ -140,8 +140,8 @@ class ResponseProcessor:
                 self.logger = self.logger.unbind('status')
 
         except MaxRetryError:
-            "Max retries exceeded ({}) attempting to send to RRM endpoint".format(retries)
-            self.logger.error()
+            msg = "Max retries exceeded ({}) attempting to send to RRM endpoint".format(retries)
+            self.logger.error(msg)
             raise RetryableError
         except ConnectionError:
             self.logger.error("Connection error occured. Retrying")

--- a/app/response_processor.py
+++ b/app/response_processor.py
@@ -63,14 +63,14 @@ class ResponseProcessor:
             collection_exercise_sid = elements[-1].split(
                 'collection_exercise_sid: ')[-1].split()[0]
 
-            self.logger.error("Receipt rejected by endpoint",
+            self.logger.error("Receipt rejected by RRM endpoint",
                               msg="No records were found on the man_ce_sample_map table",
                               error=1009,
                               stat_unit_id=stat_unit_id,
                               collection_exercise_sid=collection_exercise_sid)
             raise QuarantinableError
         else:
-            self.logger.error("Bad response from endpoint")
+            self.logger.error("Bad response from RRM endpoint")
             raise RetryableError
 
     def _decrypt(self, token, secret):
@@ -129,15 +129,15 @@ class ResponseProcessor:
                 return response
             except HTTPError:
                 if response.status_code == 400:
-                    self.logger.error("Receipt rejected by endpoint")
+                    self.logger.error("Receipt rejected by RRM endpoint")
                     raise QuarantinableError
                 elif response.status_code == 404:
                     self._check_namespace_error(response)
                 else:
-                    self.logger.error("Bad response from endpoint")
+                    self.logger.error("Bad response from RRM endpoint")
                     raise RetryableError
         except MaxRetryError:
-            "Max retries exceeded ({}) attempting to send to endpoint".format(retries)
+            "Max retries exceeded ({}) attempting to send to RRM endpoint".format(retries)
             self.logger.error()
             raise RetryableError
         except ConnectionError:

--- a/app/response_processor.py
+++ b/app/response_processor.py
@@ -136,6 +136,9 @@ class ResponseProcessor:
                 else:
                     self.logger.error("Bad response from RRM endpoint")
                     raise RetryableError
+            finally:
+                self.logger = self.logger.unbind('status')
+
         except MaxRetryError:
             "Max retries exceeded ({}) attempting to send to RRM endpoint".format(retries)
             self.logger.error()
@@ -146,3 +149,5 @@ class ResponseProcessor:
         except RequestException:
             self.logger.error("Unknown exception occured")
             raise RetryableError
+        finally:
+            self.logger.unbind('request_url')

--- a/app/response_processor.py
+++ b/app/response_processor.py
@@ -117,8 +117,8 @@ class ResponseProcessor:
             self.logger.info("Calling external receipting service", service="External receipt")
             session = Session()
             retries = Retry(total=self._retries, backoff_factor=0.5)
-            session.mount('http://', HTTPAdapter(max_retries=self._retries))
-            session.mount('https://', HTTPAdapter(max_retries=self._retries))
+            session.mount('http://', HTTPAdapter(max_retries=retries))
+            session.mount('https://', HTTPAdapter(max_retries=retries))
 
             response = session.post(endpoint, data=xml, headers=headers, verify=False, auth=auth)
             self.logger = self.logger.bind(status=response.status_code)
@@ -140,8 +140,8 @@ class ResponseProcessor:
                 self.logger = self.logger.unbind('status')
 
         except MaxRetryError:
-            msg = "Max retries exceeded ({}) attempting to send to RRM endpoint".format(retries)
-            self.logger.error(msg)
+            msg = "Max retries exceeded. Attempting to send to RRM endpoint"
+            self.logger.error(msg, retries=self._retries)
             raise RetryableError
         except ConnectionError:
             self.logger.error("Connection error occured. Retrying")

--- a/app/settings.py
+++ b/app/settings.py
@@ -1,8 +1,5 @@
 import logging
 import os
-import requests
-from requests.packages.urllib3.util.retry import Retry
-from requests.adapters import HTTPAdapter
 
 LOGGING_LEVEL = logging.getLevelName(os.getenv('LOGGING_LEVEL', 'DEBUG'))
 
@@ -36,9 +33,3 @@ RABBIT_URL2 = 'amqp://{user}:{password}@{hostname}:{port}/{vhost}'.format(
 )
 
 RABBIT_URLS = [RABBIT_URL, RABBIT_URL2]
-
-# Configure the number of retries attempted before failing call
-session = requests.Session()
-retries = Retry(total=5, backoff_factor=0.1)
-session.mount('http://', HTTPAdapter(max_retries=retries))
-session.mount('https://', HTTPAdapter(max_retries=retries))

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,5 +1,5 @@
 flake8==2.6.0
 mock==2.0.0
-responses==0.5.1
+responses==0.8.0
 six==1.10.0
 structlog==16.1.0

--- a/tests/test_response_processor.py
+++ b/tests/test_response_processor.py
@@ -101,6 +101,11 @@ class TestSend(unittest.TestCase):
         responses.add(responses.POST, self.endpoint, status=200)
         processor._send_receipt(self.decrypted, self.xml)
 
+    def test_with_none_endpoint(self):
+        with mock.patch('app.receipt.get_receipt_endpoint', return_value=None):
+            with self.assertRaises(QuarantinableError):
+                processor._send_receipt(self.decrypted, self.xml)
+
     @responses.activate
     def test_quarantinable_error_if_endpoint_none(self):
         responses.add(responses.POST, self.endpoint, status=200)

--- a/tests/test_response_processor.py
+++ b/tests/test_response_processor.py
@@ -1,20 +1,19 @@
-import unittest
+import logging
 import mock
 import json
+import unittest
 import xml.etree.cElementTree as etree
 
 from cryptography.fernet import Fernet, InvalidToken
 import responses
+from sdc.rabbit.exceptions import QuarantinableError, RetryableError
+from structlog import wrap_logger
 
 from app.response_processor import ResponseProcessor
 from app.helpers.exceptions import DecryptError
-from sdc.rabbit.exceptions import QuarantinableError, RetryableError
-from tests.test_data import test_secret, test_data
 from app import receipt
 from app import settings
-
-import logging
-from structlog import wrap_logger
+from tests.test_data import test_secret, test_data
 
 logger = wrap_logger(logging.getLogger(__name__))
 processor = ResponseProcessor(logger)
@@ -26,31 +25,29 @@ def encrypt(plain):
     return f.encrypt(plain.encode("utf-8"))
 
 
-class MockResponse:
-    def __init__(self, status):
-        self.status_code = status
-        self.url = ""
-
-
 class TestResponseProcessor(unittest.TestCase):
 
+    endpoint = 'http://sdx-mock-receipt:5000/' + \
+               'reportingunits/12345678901/collectionexercises/hfjdskf/receipts'
+
+    @responses.activate
     def test_with_valid_data(self):
-        with mock.patch('app.response_processor.session.post') as session_mock:
-            session_mock.return_value = MockResponse(status=200)
-            processor.process(encrypt(test_data['valid']))
+        responses.add(responses.POST, self.endpoint, status=200)
+        processor.process(encrypt(test_data['valid']))
 
+    @responses.activate
     def test_with_invalid_data(self):
-        with mock.patch('app.response_processor.session.post') as session_mock:
-            session_mock.return_value = MockResponse(status=200)
-            for case in ('invalid', 'missing_metadata'):
-                with self.assertRaises(QuarantinableError):
-                    processor.process(encrypt(test_data[case]))
+        responses.add(responses.POST, self.endpoint, status=200)
+        for case in ('invalid', 'missing_metadata'):
+            with self.assertRaises(QuarantinableError):
+                processor.process(encrypt(test_data[case]))
 
+    @responses.activate
     def test_exception_in_process(self):
-        with mock.patch('app.response_processor.session.post'):
-            with mock.patch('app.response_processor.ResponseProcessor._decrypt', side_effect=Exception):
-                with self.assertRaises(DecryptError):
-                    processor.process(encrypt(test_data['valid']))
+        responses.add(responses.POST, self.endpoint, status=200)
+        with mock.patch('app.response_processor.ResponseProcessor._decrypt', side_effect=Exception):
+            with self.assertRaises(DecryptError):
+                processor.process(encrypt(test_data['valid']))
 
 
 class TestDecrypt(unittest.TestCase):
@@ -87,32 +84,36 @@ class TestEncode(unittest.TestCase):
 
 class TestSend(unittest.TestCase):
 
+    endpoint = 'http://sdx-mock-receipt:5000/' + \
+               'reportingunits/12345678901/collectionexercises/hfjdskf/receipts'
+
     def setUp(self):
         self.decrypted = json.loads(test_data['valid'])
         self.xml = processor._encode(self.decrypted)
 
+    @responses.activate
     def test_with_200_response(self):
-        with mock.patch('app.response_processor.session.post') as session_mock:
-            session_mock.return_value = MockResponse(status=200)
+        responses.add(responses.POST, self.endpoint, status=200)
+        processor._send_receipt(self.decrypted, self.xml)
+
+    @responses.activate
+    def test_quarantinable_error_if_endpoint_none(self):
+        responses.add(responses.POST, self.endpoint, status=200)
+        with mock.patch('app.receipt.get_receipt_endpoint', return_value=None):
+            with self.assertRaises(QuarantinableError):
+                processor._send_receipt(self.decrypted, self.xml)
+
+    @responses.activate
+    def test_with_500_response(self):
+        responses.add(responses.POST, self.endpoint, status=500)
+        with self.assertRaises(RetryableError):
             processor._send_receipt(self.decrypted, self.xml)
 
-    def test_quarantinable_error_if_endpoint_none(self):
-        with mock.patch('app.response_processor.session.post'):
-            with mock.patch('app.receipt.get_receipt_endpoint', return_value=None):
-                with self.assertRaises(QuarantinableError):
-                    processor._send_receipt(self.decrypted, self.xml)
-
-    def test_with_500_response(self):
-        with self.assertRaises(RetryableError):
-            with mock.patch('app.response_processor.session.post') as session_mock:
-                session_mock.return_value = MockResponse(status=500)
-                processor._send_receipt(self.decrypted, self.xml)
-
+    @responses.activate
     def test_with_400_response(self):
+        responses.add(responses.POST, self.endpoint, status=400)
         with self.assertRaises(QuarantinableError):
-            with mock.patch('app.response_processor.session.post') as session_mock:
-                session_mock.return_value = MockResponse(status=400)
-                processor._send_receipt(self.decrypted, self.xml)
+            processor._send_receipt(self.decrypted, self.xml)
 
     @responses.activate
     def test_with_404_response(self):
@@ -151,3 +152,11 @@ class TestSend(unittest.TestCase):
 
         with self.assertRaises(QuarantinableError):
             resp = processor._send_receipt(self.decrypted, self.xml)  # noqa
+
+        @responses.activate
+        def test_network_error(self):
+            """Test that a RetryableError is raised when anything goes wrong at the
+            network level."""
+            responses.add(responses.POST, self.endpoint, body=ConnectionError('error'))
+            with self.assertRaises(RetryableError):
+                processor._send_receipt(self.decrypted, self.xml)


### PR DESCRIPTION
## What? and Why?
> This pull request introduces additional exception handling to catch events originating from the network, specifically any exception that is a `ConnectionError` or sub-class thereof. When this exception occurs the event is logged and the message is requed using the sdc-rabbit-library `RetryableError`.

- [x] CHANGELOG.md updated? (if required)
