### PR TITLE
Get tx id from header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Unreleased
   - Add all service config to config file
+  - Ensure tx_id is being passed in header
 
 ### 2.7.0 2017-10-16
   - Hardcode unchanging variables in settings.py to make configuration management simpler

--- a/app/main.py
+++ b/app/main.py
@@ -27,8 +27,7 @@ def run():
         rabbit_queue=app.settings.RABBIT_QUEUE,
         rabbit_urls=app.settings.RABBIT_URLS,
         quarantine_publisher=quarantine_publisher,
-        process=response_processor.process,
-        check_tx_id=False
+        process=response_processor.process
     )
 
     try:

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -5,5 +5,6 @@ test_data = {
         '{"tx_id":"0f534ffc-9442-414c-b39f-a756b4adc6cb","collection":'
         '{"exercise_sid":"hfjdskf"},"metadata":{"user_id":"789473423","ru_ref":"12345678901A"}}',
     'invalid': '{"cats":"are nice"}',
-    'missing_metadata': '{"tx_id":"0f534ffc-9442-414c-b39f-a756b4adc6cb","collection":{"exercise_sid":"hfjdskf"}}'
+    'missing_metadata': '{"tx_id":"0f534ffc-9442-414c-b39f-a756b4adc6cb","collection":{"exercise_sid":"hfjdskf"}}',
+    'missing_tx_id': '{"collection":''{"exercise_sid":"hfjdskf"},"metadata":{"user_id":"789473423","ru_ref":"12345678901A"}}'
 }

--- a/tests/test_response_processor.py
+++ b/tests/test_response_processor.py
@@ -7,7 +7,7 @@ import xml.etree.cElementTree as etree
 from cryptography.fernet import Fernet, InvalidToken
 import responses
 from requests.exceptions import ConnectionError
-from requests.packages.urllib3.exceptions import MaxRetryError
+from urllib3.exceptions import MaxRetryError
 from sdc.rabbit.exceptions import QuarantinableError, RetryableError
 from structlog import wrap_logger
 
@@ -43,6 +43,12 @@ class TestResponseProcessor(unittest.TestCase):
         for case in ('invalid', 'missing_metadata'):
             with self.assertRaises(QuarantinableError):
                 processor.process(encrypt(test_data[case]))
+
+    @responses.activate
+    def test_missing_tx_id(self):
+        responses.add(responses.POST, self.endpoint, status=200)
+        with self.assertRaises(QuarantinableError):
+            processor.process(encrypt(test_data['missing_tx_id']))
 
     @responses.activate
     def test_max_retries(self):


### PR DESCRIPTION
## What? and Why?
> What does this pull request change/fix? Why was it necessary?

Get tx_id from header. This makes logging and monitoring of the service easier.

## Checklist
  - [x] CHANGELOG.md updated? (if required)
