### PR TITLE
Remove second rabbit url host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### Unreleased
+  - Remove second rabbit host
 
 ### 2.11.0 2018-03-06
   - Send receipts to RM based on the presence of a case_id field

--- a/app/settings.py
+++ b/app/settings.py
@@ -48,12 +48,4 @@ else:
         vhost=os.getenv('RABBITMQ_DEFAULT_VHOST', '%2f')
     ) + HEARTBEAT_INTERVAL
 
-    RABBIT_URL2 = 'amqp://{user}:{password}@{hostname}:{port}/{vhost}'.format(
-        hostname=os.getenv('RABBITMQ_HOST2', 'rabbit'),
-        port=os.getenv('RABBITMQ_PORT2', 5672),
-        user=os.getenv('RABBITMQ_DEFAULT_USER', 'rabbit'),
-        password=os.getenv('RABBITMQ_DEFAULT_PASS', 'rabbit'),
-        vhost=os.getenv('RABBITMQ_DEFAULT_VHOST', '%2f')
-    ) + HEARTBEAT_INTERVAL
-
-RABBIT_URLS = [RABBIT_URL, RABBIT_URL2]
+RABBIT_URLS = [RABBIT_URL]

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -20,4 +20,3 @@ class TestSettings(unittest.TestCase):
 
     def test_heartbeat(self):
         self.assertEqual("amqp://rabbit:rabbit@rabbit:5672/%2f?heartbeat_interval=5", settings.RABBIT_URL)
-        self.assertEqual("amqp://rabbit:rabbit@rabbit:5672/%2f?heartbeat_interval=5", settings.RABBIT_URL2)


### PR DESCRIPTION
## What? and Why?
Remove the second rabbit host url in preparation of the move to AWS corp where there is a load balance in front of the rabbit cluster

## Checklist
  - [x] CHANGELOG.md updated? (if required)
