### PR TITLE
Improve logging , add check for tx_id mismatch.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ### Unreleased
 
+### 2.15.1 2019-02-27
+  - Bound case_id , tx_id and user_id to logger
+
 ### 2.15.0 2019-01-22
   - Add userId to receipt
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,4 @@
 ### Unreleased
-
-### 2.15.1 2019-02-27
   - Bound case_id , tx_id and user_id to logger
 
 ### 2.15.0 2019-01-22

--- a/app/response_processor.py
+++ b/app/response_processor.py
@@ -1,5 +1,4 @@
 from json import loads
-import logging
 
 from cryptography.fernet import Fernet
 from requests import Session
@@ -7,17 +6,14 @@ from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.exceptions import MaxRetryError
 from requests.packages.urllib3.util.retry import Retry
 from sdc.rabbit.exceptions import RetryableError, QuarantinableError
-from structlog import wrap_logger
 
 from app import settings
 from app.helpers.exceptions import DecryptError
 
-local_logger = wrap_logger(logging.getLogger(__name__))
-
 
 class ResponseProcessor:
 
-    def __init__(self, logger=local_logger):
+    def __init__(self, logger):
         self.logger = logger
         self._retries = 5
         self.session = Session()

--- a/tests/test_response_processor.py
+++ b/tests/test_response_processor.py
@@ -1,5 +1,6 @@
 import mock
 import json
+import logging
 import unittest
 
 from cryptography.fernet import Fernet, InvalidToken
@@ -7,13 +8,16 @@ import responses
 from requests.packages.urllib3 import HTTPConnectionPool
 from requests.packages.urllib3.exceptions import MaxRetryError
 from sdc.rabbit.exceptions import QuarantinableError, RetryableError
+from structlog import wrap_logger
 
 from app.response_processor import ResponseProcessor
 from app.helpers.exceptions import DecryptError
 from app import settings
 from tests.test_data import test_secret, test_data
 
-processor = ResponseProcessor()
+logger = wrap_logger(logging.getLogger(__name__))
+
+processor = ResponseProcessor(logger)
 settings.SDX_RECEIPT_RRM_SECRET = test_secret
 
 

--- a/tests/test_response_processor.py
+++ b/tests/test_response_processor.py
@@ -37,13 +37,54 @@ class TestResponseProcessor(unittest.TestCase):
     def test_missing_tx_id(self):
         responses.add(responses.POST, self.endpoint, status=200)
         with self.assertRaises(QuarantinableError):
-            processor.process(encrypt(test_data['missing_tx_id']))
+            with self.assertLogs() as cm:
+                processor.process(encrypt(test_data['missing_tx_id']))
+            self.assertIn('Decrypted json missing tx_id . Quarantining message', cm.output[0])
 
     @responses.activate
     def test_missing_case_id(self):
         responses.add(responses.POST, self.endpoint, status=200)
         with self.assertRaises(QuarantinableError):
-            processor.process(encrypt(test_data['missing_case_id']))
+            with self.assertLogs() as cm:
+                processor.process(encrypt(test_data['missing_case_id']))
+            self.assertIn('Decrypted json missing metadata. Quarantining message', cm.output[0])
+
+    @responses.activate
+    def test_missing_metadata(self):
+        responses.add(responses.POST, self.endpoint, status=201)
+        with self.assertRaises(QuarantinableError):
+            with self.assertLogs() as cm:
+                processor.process(encrypt(test_data['missing_metadata']))
+            self.assertIn('Decrypted json missing metadata. Quarantining message', cm.output[0])
+
+    @responses.activate
+    def test_successful_logs_contain_bound_parameters(self):
+        responses.add(responses.POST, self.endpoint, status=201)
+        with self.assertLogs() as cm:
+            processor.process(encrypt(test_data['valid']))
+        self.assertIn('tx_id', cm.output[0])
+        self.assertIn('case_id', cm.output[0])
+        self.assertIn('user_id', cm.output[0])
+        self.assertIn('RM submission received', cm.output[0])
+        self.assertIn('tx_id', cm.output[1])
+        self.assertIn('case_id', cm.output[1])
+        self.assertIn('user_id', cm.output[1])
+        self.assertIn('RM sdx gateway receipt creation was a success', cm.output[1])
+
+    @responses.activate
+    def test_tx_id_in_header_not_matching_tx_id_in_message_leads_to_message_in_logs(self):
+        responses.add(responses.POST, self.endpoint, status=201)
+        with self.assertRaises(QuarantinableError):
+            with self.assertLogs() as cm:
+                processor.process(encrypt(test_data['valid']), 'bad_tx_id')
+            self.assertIn('tx_ids from decrypted_json and message header do not match. Quarantining message', cm.output[0])
+
+    @responses.activate
+    def test_tx_id_in_header_matching_tx_id_in_message(self):
+        responses.add(responses.POST, self.endpoint, status=201)
+        with self.assertLogs() as cm:
+            processor.process(encrypt(test_data['valid']), '0f534ffc-9442-414c-b39f-a756b4adc6cb')
+        self.assertEquals(len(cm.output), 2)
 
 
 class TestDecrypt(unittest.TestCase):
@@ -66,11 +107,11 @@ class TestDecrypt(unittest.TestCase):
 
 class TestValidate(unittest.TestCase):
     def test_valid_data(self):
-        processor._validate(json.loads(test_data['valid']))
+        processor._validate(json.loads(test_data['valid']), None)
 
     def test_missing_metadata(self):
         with self.assertRaises(QuarantinableError):
-            processor._validate(json.loads(test_data['missing_metadata']))
+            processor._validate(json.loads(test_data['missing_metadata']), None)
 
 
 class TestRMReceipt(unittest.TestCase):


### PR DESCRIPTION
## What? and Why?
> tx_id, case_id and user_id where not showing in logs . This was to bind those
These were added, but it was also noticed that there was no check comparing tx_id in header to message, and an incorrect logger was being used. Changed to use correct logger, bound the required variables and updated tests

To test:
Run unit tests 
Run in sdx compose use grep to filter to sdx-receipt-rrm_1 messages. Submit message via console and validate that user id , tx_id and case_id appear in the logs 

## Checklist
  - [ ] CHANGELOG.md updated? Yes
