### PR TITLE
Add python 3.8 to travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 dist: xenial
 python:
+    - "3.8"
     - "3.7"
     - "3.6"
 sudo: required

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### Unreleased
+  - Add python 3.8 to travis builds
 
 ### 2.18.0 2019-09-04
   - Updated sdc-rabbit to 1.7.0 to fix reconnection issues


### PR DESCRIPTION
## What? and Why?
Add python 3.8 to travis builds so we can have confidence in our system when we end up upgrading the version of python we use

## Checklist
  - [x] CHANGELOG.md updated? (if required)
