### PR TITLE
Add a timeout and more error logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### Unreleased
+  - Add 60 second timeout to requests and add error logging
 
 ### 2.18.1 2019-11-08
   - Add python 3.8 to travis builds


### PR DESCRIPTION
## What? and Why?
The connection to the gateway wasn't working but there wasn't any logging happening around it.  We've added a timeout and extra logging to give us more information in the future if something goes wrong.

## Checklist
  - [x] CHANGELOG.md updated? (if required)
