### PR TITLE
update send receipt to use https

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### Unreleased
+  - send receipt to use https
 
 ### 2.18.3 2020-06-09
   - Remove Cloudfoundry deployment files

--- a/app/response_processor.py
+++ b/app/response_processor.py
@@ -87,11 +87,11 @@ class ResponseProcessor:
 
     def _send_rm_receipt(self, case_id, user_id):
         request_url = settings.RM_SDX_GATEWAY_URL
-        location = settings.RM_SDX_GATEWAY_CERT_LOCATION
+        cert_location = settings.RM_SDX_GATEWAY_CERT_LOCATION
         request_json = {'caseId': case_id,
                         'userId': user_id}
         try:
-            r = self.session.post(request_url, verify=location, auth=settings.BASIC_AUTH, json=request_json, timeout=60)
+            r = self.session.post(request_url, verify=cert_location, auth=settings.BASIC_AUTH, json=request_json, timeout=60)
         except MaxRetryError:
             self.logger.error("Max retries exceeded (5)",
                               request_url=request_url)

--- a/app/response_processor.py
+++ b/app/response_processor.py
@@ -87,10 +87,11 @@ class ResponseProcessor:
 
     def _send_rm_receipt(self, case_id, user_id):
         request_url = settings.RM_SDX_GATEWAY_URL
+        location = settings.RM_SDX_GATEWAY_CERT_LOCATION
         request_json = {'caseId': case_id,
                         'userId': user_id}
         try:
-            r = self.session.post(request_url, auth=settings.BASIC_AUTH, json=request_json, timeout=60)
+            r = self.session.post(request_url, verify=location, auth=settings.BASIC_AUTH, json=request_json, timeout=60)
         except MaxRetryError:
             self.logger.error("Max retries exceeded (5)",
                               request_url=request_url)

--- a/app/settings.py
+++ b/app/settings.py
@@ -17,7 +17,7 @@ if SDX_RECEIPT_RRM_SECRET is not None:
     SDX_RECEIPT_RRM_SECRET = SDX_RECEIPT_RRM_SECRET.encode("ascii")
 
 RM_SDX_GATEWAY_URL = os.getenv("RM_SDX_GATEWAY_URL", "http://sdx-mock-receipt:5000/receipts")
-
+RM_SDX_GATEWAY_CERT_LOCATION = os.getenv("RM_SDX_GATEWAY_CERT_LOCATION", "path/to/ons.pem")
 
 RABBIT_URL = 'amqp://{user}:{password}@{hostname}:{port}/{vhost}'.format(
     hostname=os.getenv('RABBITMQ_HOST', 'rabbit'),

--- a/app/settings.py
+++ b/app/settings.py
@@ -17,7 +17,7 @@ if SDX_RECEIPT_RRM_SECRET is not None:
     SDX_RECEIPT_RRM_SECRET = SDX_RECEIPT_RRM_SECRET.encode("ascii")
 
 RM_SDX_GATEWAY_URL = os.getenv("RM_SDX_GATEWAY_URL", "http://sdx-mock-receipt:5000/receipts")
-RM_SDX_GATEWAY_CERT_LOCATION = os.getenv("RM_SDX_GATEWAY_CERT_LOCATION", "path/to/ons.pem")
+RM_SDX_GATEWAY_CERT_LOCATION = os.getenv("RM_SDX_GATEWAY_CERT_LOCATION", False)
 
 RABBIT_URL = 'amqp://{user}:{password}@{hostname}:{port}/{vhost}'.format(
     hostname=os.getenv('RABBITMQ_HOST', 'rabbit'),


### PR DESCRIPTION
## What? and Why?
Change send receipt method to use https. his is to make the connection between sdx and rasrm more secure.

## Checklist
  - [x] CHANGELOG.md updated? (if required)
